### PR TITLE
Add initial OpenTofu config for Proxmox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# OpenTofu / Terraform state
+.terraform/
+*.tfstate
+*.tfstate.*
+
+# Crash logs
+crash.log
+crash.*.log
+
+# Ignore override files
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+

--- a/opentofu/.terraform.lock.hcl
+++ b/opentofu/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/telmate/proxmox" {
+  version     = "2.9.14"
+  constraints = "~> 2.9"
+  hashes = [
+    "h1:H/f+LbVyPOLslHLAYnGuMMRqWFZ65K6E3V+MCYgfAyk=",
+    "zh:0d049d33f705e5b814d30028770c084151218439424e99684ce31d7e26a720b5",
+    "zh:20b1c64ed56d81de95f3f37b82b45b4654c0de26670c0e87a474c5cce13cd015",
+    "zh:2946058abd1d8e50e475b9ec39781eb02576b40dbd80f4653fade4493a4514c6",
+    "zh:29e50a25c456f040ce072f23ac57b5b82ebd3b916ca5ae6688332b5ec62adc4a",
+    "zh:3612932306ce5f08db94868f526cbb8c56d0d3c6ebe1c11a83f92bbf94354296",
+    "zh:42d1699b0abebaac82ea5a19f4393541d8bb2741bde204a8ac1028cdc29d1b14",
+    "zh:5ffd5dc567262eb8aafdf2f6eac63f7f21361da9c5d75a3c36b479638a0001b0",
+    "zh:6692ef323e3b89de99934ad731f6a1850525bf8142916ae28ea4e4048d73a787",
+    "zh:a5afc98e9a4038516bb58e788cb77dea67a60dce780dfcd206d7373c5a56b776",
+    "zh:bf902cded709d84fa27fbf91b589c241f2238a6c4924e4e479eebd74320b93a5",
+    "zh:cab0e1e72c9cebcf669fc6f35ec28cb8ab2dffb0237afc8860aa40d23bf8a49f",
+    "zh:e523b99a48beec83d9bc04b2d336266044f9f53514cefb652fe6768611847196",
+    "zh:f593915e8a24829d322d2eaeedcb153328cf9042f0d84f66040dde1be70ede04",
+    "zh:fba1aff541133e2129dfda0160369635ab48503d5c44b8407ce5922ecc15d0bd",
+  ]
+}

--- a/opentofu/main.tf
+++ b/opentofu/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "Telmate/proxmox"
+      version = "~> 2.9"
+    }
+  }
+}
+
+provider "proxmox" {
+  endpoint = var.pm_api_url
+  username = var.pm_user
+  password = var.pm_password
+  insecure = var.pm_tls_insecure
+}

--- a/opentofu/variables.tf
+++ b/opentofu/variables.tf
@@ -1,0 +1,21 @@
+variable "pm_api_url" {
+  description = "Proxmox API endpoint, e.g. https://proxmox.example:8006/api2/json"
+  type        = string
+}
+
+variable "pm_user" {
+  description = "Proxmox user including realm, e.g. root@pam"
+  type        = string
+}
+
+variable "pm_password" {
+  description = "Password for the Proxmox user"
+  type        = string
+  sensitive   = true
+}
+
+variable "pm_tls_insecure" {
+  description = "Skip TLS verification for the Proxmox API"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary
- add OpenTofu configuration for Proxmox provider and basic variables
- ignore OpenTofu state and crash files

## Testing
- `cd opentofu && tofu fmt -check && cd ..`
- `cd opentofu && TF_VAR_pm_api_url="https://proxmox.example:8006/api2/json" TF_VAR_pm_user="root@pam" TF_VAR_pm_password="secret" tofu validate && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_688c3d0b277c8321bae7293e1a3d66da